### PR TITLE
document a limitation in the original Pod tables

### DIFF
--- a/rakudoc_draft_3.rakudoc
+++ b/rakudoc_draft_3.rakudoc
@@ -1742,9 +1742,18 @@ or with multi-line headers I<and> multi-line data:
     =end table
 =end code
 
-Although headers can be specified using multiple lines, for legacy reasons a renderer
-may treat the header text in a single column as a single string. For more control
-over header rows and labelled columns, use a I<procedural> table.
+Visual-style tables can only have a single header row (namely: everything
+before the first C<=====> line). That single header may, however, span one or
+more initial lines of the visual table specification, as some of the
+preceding examples illustrate. However, regardless of how many lines a
+visual-style header spans, it is always treated as a single header row.
+Individual renderers are free to choose how they represent visual header
+contents that have line breaks in them: they may treat them as a single
+string to be reflowed and wrapped, or they may elect to preserve the
+original line breaks within each header cell. The only requirement is
+that the entire header of a visual-style table must be rendered as a single
+row of cells. If two or more header rows are required, use a
+I<procedural table> instead.
 
 =head4 Valid tables
 

--- a/rakudoc_draft_3.rakudoc
+++ b/rakudoc_draft_3.rakudoc
@@ -1,5 +1,5 @@
 =begin rakudoc :kind("Language") :subkind("Language") :category("reference")
-=VERSION 2.5.1
+=VERSION 2.5.2
 =TITLE RakuDoc
 =SUBTITLE A Raku slang for documenting Raku software to aid development and use.
 
@@ -1741,6 +1741,10 @@ or with multi-line headers I<and> multi-line data:
 
     =end table
 =end code
+
+Although headers can be specified using multiple lines, for legacy reasons a renderer
+may treat the header text in a single column as a single string. For more control
+over header rows and labelled columns, use a I<procedural> table.
 
 =head4 Valid tables
 


### PR DESCRIPTION
- parsing and processing of Pod Table assumed only one header row
- changing this behaviour turns out to be more complex.
- since the extra flexibility is in procedural tables, it seems a case of diminishing returns to get multiple lines in a text-table header.

@thoughtstream @lizmat thoughts?