### PR TITLE
Clarify :alt re PR 55

### DIFF
--- a/rakudoc_draft_3.rakudoc
+++ b/rakudoc_draft_3.rakudoc
@@ -2686,8 +2686,8 @@ If a renderer does not recognize a custom block, then the renderer should replac
 block's C< :alt<...> > option (if provided). If the document author did not include an C< :alt<...> > option, then the
 renderer should treat the block name as the contents of a C<=head1> block, which can be overridden as described in 
 L<Table of Contents|#Table of Contents and Index> and should render the contents of the unrecognized custom block verbatim,
-like a C<=code> block. An unrecognized custom block without a C< :alt<...> > option should generate a warning message unless
-the custom block is passed the C< :!warn > option.
+like a C<=code> block. Any unrecognized custom block (with or without an C< :alt<...> > option) should generate a warning
+message unless the custom block is passed the C< :!warn > option.
 
 Multi-paragraph contents should be enclosed using the I<delimited> form of the block.
 

--- a/rakudoc_draft_3.rakudoc
+++ b/rakudoc_draft_3.rakudoc
@@ -2682,16 +2682,12 @@ and custom blocks are never mixed up.
 The way in which a renderer styles the contents of a custom block depends on the renderer, and each renderer
 may specify a procedure for using user-supplied templates or code.
 
-If a renderer does not recognise a custom block, then by default the renderer should treat the block name as the contents of a
-C<=head1> block, which can be overridden as described in L<Table of Contents|#Table of Contents and Index>. The
-contents of the unrecognised custom block should be rendered verbatim, like a C<=code> block.
-
-It is possible that a custom block contains data, eg., the text form of an image, which should only
-be displayed with the custom block. If the renderer does not recognise the custom block, the
-document author should include an C< :alt<...> > option. The contents of the option will be rendered
-in place of the contents of the custom block.
-
-By default an unrecognised custom block will generate an error message.
+If a renderer does not recognize a custom block, then the renderer should replace that block with the contents of the
+block's C< :alt<...> > option (if provided). If the document author did not include an C< :alt<...> > option, then the
+renderer should treat the block name as the contents of a C<=head1> block, which can be overridden as described in 
+L<Table of Contents|#Table of Contents and Index> and should render the contents of the unrecognized custom block verbatim,
+like a C<=code> block. An unrecognized custom block without a C< :alt<...> > option should generate a warning message unless
+the custom block is passed the C< :!warn > option.
 
 Multi-paragraph contents should be enclosed using the I<delimited> form of the block.
 


### PR DESCRIPTION
I was pinged on #55 but didn't get the chance to respond before it was merged (sorry!).

I was slightly confused by the language in #55 – is the intent to display a warning only when an unsupported custom block doesn't supply an `:alt` text? Or any time it can't be rendered? I also think it's a bit confusing to define the "default" rendering for an unsupported custom block but then say that using the `:alt` option overrides that default.

This PR re-words the language added in PR #55 for to clarify both of those issues. Specifically, this clarifies that the default only applies in the absence of an `:alt` option and that the warning is only shown when that default rendering is used. IIUC, this preserves the intended behavior from #55 (just stated more explicitly). But please feel free to say that I misunderstood the intent! 