### PR TITLE
Rewrite config example

### DIFF
--- a/rakudoc_draft_3.rakudoc
+++ b/rakudoc_draft_3.rakudoc
@@ -2518,13 +2518,12 @@ We will use the identity: F<\sum \frac{1}{n^{2}} = \frac{\pi^{2}}{6}>
 
 ...may either be rendered “accurately”:
 =begin nested
-=begin code :lang<text>
 We will use the identity: F<\sum \frac{1}{n^{2}} = \frac{\pi^{2}}{6}>
 
 ...where the value of pi can be inferred from Euler’s Identity:
 
-=formula e^{i\pi}+1=0
-=end code
+=for formula :!toc :caption('')
+e^{i\pi}+1=0
 =end nested
 
 ... or may be converted to a suitable Unicode approximation:
@@ -2534,7 +2533,9 @@ We will use the identity: ∑ 1/n² = 𝜋²/6
 
 ...where the value of pi can be inferred from Euler’s Identity:
 
-eⁱᐢ + 1 = 0
+=for formula :!toc :caption('')
+e^{i\pi}+1=0
+
 =end nested
 
 ... or may even left as raw LaTeX (perhaps with some kind of visual marker indicating

--- a/rakudoc_draft_3.rakudoc
+++ b/rakudoc_draft_3.rakudoc
@@ -554,27 +554,34 @@ Successive C<=config> directives within the same scope are cumulative in effect.
 Because C<=config> directives specify I<default> behaviours, whenever a particular kind of metadata
 is explicitly specified for an instance of that block type, that option overrides the defaults set by any active C<=config> blocks.
 For example:
-=begin code :lang<RakuDoc>
+=begin code :allow<B>
     B<=config item1 :bullet« \c[Earth Globe Europe-Africa] » >
     B<=config item2 :bullet« \c[Hand with Index and Middle Fingers Crossed] » >
-    # In the list, =item1 and =item2 will have non-standard bullets
+    =comment  In the following list, =item1 and =item2 will now have non-standard bullets
+
     The major sources of sustainable energy are:
         =item1 geothermal
         =item1 fusion
         =item2 (eventually)
+
     =begin section
         B<=config item1 :toc :headerlevel(2)>
+        =comment  The following items still have non-standard bullets but now they will
+                  also be added to the table of contents as if they were =head2 blocks
+
         Important items are:
-        =comment the following items will be added to the table of contents as if they are
-        head2 blocks
+            =item1 small scale fusion
+            =item1 room temperature superconductors
 
-        =item1 small scale fusion
-        =item1 room temperature superconductors
     =end section
-    =comment the following list item will not be added to the Table of contents
-    because the section has ended
 
-    =item1 so ends the list, but it will still have the Earth bullet
+    =comment  The following list items will NOT be added to the Table of Contents
+              because the section containing that particular =config has now ended.
+              They will still have the non-standard Earth bullets though,
+              because those two =config directives are still in scope.
+
+        =item1 matter-antimatter annihilation
+        =item1 zero-point energy
 =end code
 
 There is more discussion of C<=config> in the context of L<Formatting codes|#Formatting codes>.

--- a/rakudoc_draft_3.rakudoc
+++ b/rakudoc_draft_3.rakudoc
@@ -555,44 +555,26 @@ Because C<=config> directives specify I<default> behaviours, whenever a particul
 is explicitly specified for an instance of that block type, that option overrides the defaults set by any active C<=config> blocks.
 For example:
 =begin code :lang<RakuDoc>
-    =config code :allow< B C I >
-    # The default metadata for any code block is now:  :allow< B C I >
-
-    =begin code
-       # In this paragraph B<this phrase will be shown as basis (possibly in bold font)>
-       # and I<this will be shown as important (possibly italics)>.
-       # But other markup such as R<placeholder> and K<input> will be shown verbatim.
-       #
-       # Because no :lang<> option was configured, the language for the block
-       # is the universal default:  :lang<Raku>
-    =end code
-
-    =config code :lang<RakuDoc>
-    # The default metadata for any code block is now:  :allow< B C I > :lang<RakuDoc>
-
-    =begin code :allow< R K >
-       # Here the explicit :allow on the block overrides the default :allow from the =config
-       # so B<markup> and I<markup> are shown verbatim, while R<this will be shown as a replacement text>.
-       #
-       # There is no explicit :lang on the code block,
-       # so the language for the block is the configured default:  :lang<RakuDoc.
-    =end code
-
-    =code # Now we're back to B<basic> and I<important>, but not R<placeholder> or K<input>
-
+    B<=config item1 :bullet« \c[Earth Globe Europe-Africa] » >
+    B<=config item2 :bullet« \c[Hand with Index and Middle Fingers Crossed] » >
+    # In the list, =item1 and =item2 will have non-standard bullets
+    The major sources of sustainable energy are:
+        =item1 geothermal
+        =item1 fusion
+        =item2 (eventually)
     =begin section
-    =config code :allow< R K >
-        # The default metadata for any code block is now:  :allow< R K > :lang<RakuDoc>
+        B<=config item1 :toc :headerlevel(2)>
+        Important items are:
+        =comment the following items will be added to the table of contents as if they are
+        head2 blocks
 
-    =begin code :lang<JavaScript>
-            // The format codes R and K are activated by default,
-            // but B<> C<> I<> markup will be shown verbatim
-            //
-            // The language has been explicitly set to Javascript
-            // (important if syntax highlighting is turned on),
-            // so the configured default language (RakuDoc) is overridden
-    =end code
+        =item1 small scale fusion
+        =item1 room temperature superconductors
     =end section
+    =comment the following list item will not be added to the Table of contents
+    because the section has ended
+
+    =item1 so ends the list, but it will still have the Earth bullet
 =end code
 
 There is more discussion of C<=config> in the context of L<Formatting codes|#Formatting codes>.


### PR DESCRIPTION
@thoughtstream The original example to show how `=config` was additive was written when we considered `:allow' and `:lang' to be completely orthogonal. After the discussion about the difficulties of rendering both a syntax highlighted and an allow highlighting, we decided to leave it to the renderer to choose.

Consequently, I thought it better to change the example to one where there are two independent options, and I know that both `:toc` and `:bullet` on a list work together.

Would you please review the change. [update: I appear to have messed up the commits and added more in this commit than I was intending. The review is requested primarily on the `rewrite config` part.